### PR TITLE
Proxies arg was being passed a unicode object when a dict is required. U...

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import ast
 #import vcr
 
 from urllib import urlencode
@@ -57,9 +58,12 @@ class RequestsKeywords(object):
         s = session = requests.Session()
         s.headers.update(headers)
         s.auth = auth if auth else s.auth
-        s.proxies = proxies if proxies else  s.proxies
-
         s.verify = self.builtin.convert_to_boolean(verify)
+        if proxies:
+            s.proxies = ast.literal_eval(proxies)
+        else:
+            s.proxies = None
+                
 
         # cant pass these into the Session anymore
         self.timeout = timeout


### PR DESCRIPTION
I am on a corporate network that forces me to go through a HTTP proxy. I discovered that when I set the argument for the proxies in a test case, the connection would timeout. After some debugging, I discovered that while the proxies argument was being set, the value was not of the right type. It was a string instead of a dict. This effectively disabled the proxy argument for the session object.

Modified the library so that the proxies argument is converted to a dict so that the session object uses that value correctly if set.