### PR TITLE
Format data according to the Content-Type on post requests

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -152,7 +152,7 @@ class RequestsKeywords(object):
             json_ = json.loads(content)
         logger.info ('To JSON using : content=%s ' % (content))
         logger.info ('To JSON using : pretty_print=%s ' % (pretty_print))
-        
+
         return json_
 
 
@@ -171,7 +171,7 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
         response = self._get_request(session, uri, headers, params, redir)
         logger.info ('Get Request using : alias=%s, uri=%s, headers=%s ' % (alias, uri, headers))
-            
+
         return response
 
 
@@ -192,7 +192,7 @@ class RequestsKeywords(object):
         params = self._utf8_urlencode(params)
         redir = True if allow_redirects is None else allow_redirects
         response = self._get_request(session, uri, headers, params, redir)
-            
+
         return response
 
 
@@ -213,7 +213,7 @@ class RequestsKeywords(object):
         `files` a dictionary of file names containing file data to POST to the server
         """
         session = self._cache.switch(alias)
-        data = self._utf8_urlencode(data)
+        data = self._format_data_according_to_header(data, headers)
         redir = True if allow_redirects is None else allow_redirects
         response = self._post_request(session, uri, data, headers, files, redir)
         logger.info ('Post Request using : alias=%s, uri=%s, data=%s, headers=%s, files=%s, allow_redirects=%s ' % (alias, uri, data, headers, files, redir))
@@ -565,3 +565,16 @@ class RequestsKeywords(object):
         temp = json.loads(content)
         return json.dumps(temp, sort_keys=True, indent=4, separators=(',', ': '))
 
+
+    def _format_data_according_to_header(self, data, headers):
+        if headers is not None and 'Content-Type' in headers:
+            if headers['Content-Type'].find("application/json") != -1:
+                data = json.dumps(data)
+            elif headers['Content-Type'].find("application/x-www-form-urlencoded") != -1:
+                data = self._utf8_urlencode(data)
+            else:
+                data = data
+        else:
+            data = data
+
+        return data

--- a/tests/Requests_Tests.robot
+++ b/tests/Requests_Tests.robot
@@ -211,14 +211,12 @@ Put Request Without Redirection
 Do Not Pretty Print a JSON object
     [Tags]    json
     Comment    Define json variable.
-    ${var}=    Create Dictionary    key_one    true    key_two    this is a test string
+    ${var}=    Create Dictionary    key_one=true    key_two=this is a test string
     ${resp}=    Get Request    httpbin    /get    params=${var}
     Set Suite Variable    ${resp}
     Should Be Equal As Strings    ${resp.status_code}    200
-    Log    ${resp.content}
     ${jsondata}=    To Json    ${resp.content}
-    Log    ${jsondata['args']}
-    Should Be Equal As Strings    ${jsondata['args']}    ${var}
+    Dictionaries Should Be Equal   ${jsondata['args']}    ${var}
 
 Pretty Print a JSON object
     [Tags]    json

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -245,14 +245,12 @@ Put Request Without Redirection
 Do Not Pretty Print a JSON object
     [Tags]    json
     Comment    Define json variable.
-    ${var}=   Create Dictionary   key_one   true     key_two     this is a test string
-    ${resp}=     Get  httpbin  /get    params=${var}
+    ${var}=    Create Dictionary    key_one=true    key_two=this is a test string
+    ${resp}=    Get Request    httpbin    /get    params=${var}
     Set Suite Variable    ${resp}
-    Should Be Equal As Strings  ${resp.status_code}  200
-    Log    ${resp.content}
-    ${jsondata}=  To Json  ${resp.content}
-    Log    ${jsondata['args']}
-    Should Be Equal As Strings    ${jsondata['args']}    ${var}
+    Should Be Equal As Strings    ${resp.status_code}    200
+    ${jsondata}=    To Json    ${resp.content}
+    Dictionaries Should Be Equal   ${jsondata['args']}    ${var}
 
 Pretty Print a JSON object
     [Tags]    json


### PR DESCRIPTION
Hi,

I tough it would be convenient to have the data automatically formatted according to the Content-Type of the request. The issue here is that some APIs will only accept a very specific format for the post data and it wasn't previously possible to have control over that.

I also fixed the tests.

Also I noticed that there is a duplicate of the test file is that normal? There is one a .robot file and one as a .txt file.

Thank you.