### PR TITLE
Restoring backward compatibility, refactoring

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -120,8 +120,8 @@ class RequestsKeywords(object):
         `verify` set to True if Requests should verify the certificate
 
         `debug` enable http verbosity option more information 
-                https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_debuglevel        
-        
+                https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_debuglevel
+
         `max_retries` The maximum number of retries each connection should attempt.
         """
         auth = requests.auth.HTTPBasicAuth(*auth) if auth else None
@@ -508,7 +508,7 @@ class RequestsKeywords(object):
 
         return response
 
-    def head_request(self, alias, uri, headers=None, allow_redirects=None):
+    def head_request(self, alias, uri, headers=None, allow_redirects=None, timeout=None):
         """ Send a HEAD request on the session object found using the
         given `alias`
 
@@ -520,7 +520,7 @@ class RequestsKeywords(object):
         """
         session = self._cache.switch(alias)
         redir = False if allow_redirects is None else allow_redirects
-        response = self._head_request(session, uri, headers, redir)
+        response = self._head_request(session, uri, headers, redir, timeout)
         logger.info('Head Request using : alias=%s, uri=%s, headers=%s, \
         allow_redirects=%s ' % (alias, uri, headers, redir))
 
@@ -541,11 +541,11 @@ class RequestsKeywords(object):
         print "Deprication Warning  Use Head Request in the future"
         session = self._cache.switch(alias)
         redir = False if allow_redirects is None else allow_redirects
-        response = self._head_request(session, uri, headers, redir)
+        response = self._head_request(session, uri, headers, redir, timeout)
 
         return response
 
-    def options_request(self, alias, uri, headers=None, allow_redirects=None):
+    def options_request(self, alias, uri, headers=None, allow_redirects=None, timeout=None):
         """ Send an OPTIONS request on the session object found using the
         given `alias`
 
@@ -557,13 +557,13 @@ class RequestsKeywords(object):
         """
         session = self._cache.switch(alias)
         redir = True if allow_redirects is None else allow_redirects
-        response = self._options_request(session, uri, headers, redir)
+        response = self._options_request(session, uri, headers, redir, timeout)
         logger.info('Options Request using : alias=%s, uri=%s, headers=%s, allow_redirects=%s '
                     % (alias, uri, headers, redir))
 
         return response
 
-    def options(self, alias, uri, headers=None, allow_redirects=None):
+    def options(self, alias, uri, headers=None, allow_redirects=None, timeout=None):
         """ * * *   Deprecated- See Options Request now   * * *
         Send an OPTIONS request on the session object found using the
         given `alias`
@@ -577,7 +577,7 @@ class RequestsKeywords(object):
         print "Deprication Warning  Use Options Request in the future"
         session = self._cache.switch(alias)
         redir = True if allow_redirects is None else allow_redirects
-        response = self._options_request(session, uri, headers, redir)
+        response = self._options_request(session, uri, headers, redir, timeout)
 
         return response
 
@@ -710,7 +710,7 @@ class RequestsKeywords(object):
         return urlencode(utf8_data)
 
     def _format_data_according_to_header(self, data, headers):
-        if headers is not None and 'Content-Type' in headers:
+        if data is not None and headers is not None and 'Content-Type' in headers:
             if headers['Content-Type'].find("application/json") != -1:
                 data = json.dumps(data)
             elif headers['Content-Type'].find("application/x-www-form-urlencoded") != -1:

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -5,7 +5,7 @@ import sys
 import logging
 import httplib
 import urlparse
-#import vcr
+# import vcr
 
 from urllib import urlencode
 from requests.auth import HTTPDigestAuth
@@ -23,13 +23,16 @@ except ImportError:
 from functools import wraps
 import time
 
+
 class RetryException(RequestException):
     pass
+
 
 def retry(ExceptionToCheck, logger=None):
     """
     Retry calling the decorated function using an exponential backoff.
     """
+
     def deco_retry(f):
         def f_retry(self, *args, **kwargs):
             mretries, mdelay, mbackoff = self.mretries, self.mdelay, self.mbackoff
@@ -37,7 +40,7 @@ def retry(ExceptionToCheck, logger=None):
                 try:
                     return f(self, *args, **kwargs)
                 except ExceptionToCheck as e:
-                    half_interval = mdelay * mbackoff #interval size
+                    half_interval = mdelay * mbackoff  # interval size
                     actual_delay = random.uniform(mdelay - half_interval, mdelay + half_interval)
                     msg = "%s, Retrying in %.2f seconds ..." % (str(e), actual_delay)
                     if logger:
@@ -54,16 +57,21 @@ def retry(ExceptionToCheck, logger=None):
                 else:
                     print msg
             return f(self, *args, **kwargs)
+
         return f_retry  # true decorator
+
     return deco_retry
 
 
 class WritableObject:
     ''' HTTP stream handler '''
+
     def __init__(self):
         self.content = []
+
     def write(self, string):
         self.content.append(string)
+
 
 class RequestsKeywords(object):
     ROBOT_LIBRARY_SCOPE = 'Global'
@@ -84,7 +92,7 @@ class RequestsKeywords(object):
             return data
 
         utf8_data = {}
-        for k,v in data.iteritems():
+        for k, v in data.iteritems():
             utf8_data[k] = unicode(v).encode('utf-8')
         return urlencode(utf8_data)
 
@@ -145,7 +153,6 @@ class RequestsKeywords(object):
         self._cache.register(session, alias=alias)
         return session
 
-
     def create_session(self, alias, url, headers={}, cookies=None,
                        auth=None, timeout=None, proxies=None,
                        verify=False, debug=0, max_retries=3, max_delay=1.0, max_backoff=0.10):
@@ -183,7 +190,6 @@ class RequestsKeywords(object):
                                   proxies, verify, debug))
         return self._create_session(alias, url, headers, cookies, auth,
                                     timeout, proxies, verify, debug, max_retries, max_delay, max_backoff)
-
 
     def create_ntlm_session(self, alias, url, auth, headers={}, cookies=None,
                             timeout=None, proxies=None, verify=False
@@ -226,15 +232,14 @@ class RequestsKeywords(object):
                         headers=%s, cookies=%s, ntlm_auth=%s, timeout=%s, \
                         proxies=%s, verify=%s, debug=%s ' \
                         % (alias, url, headers, cookies, ntlm_auth, \
-                        timeout, proxies, verify, debug))
+                           timeout, proxies, verify, debug))
             return self._create_session(alias, url, headers, cookies,
                                         ntlm_auth, timeout, proxies, verify,
                                         debug, max_retries, max_delay, max_backoff)
 
-
     def create_digest_session(self, alias, url, auth, headers={}, cookies=None,
-                                timeout=None, proxies=None, verify=False,
-                                debug=0, max_retries=3, max_delay=1.0, max_backoff=0.10):
+                              timeout=None, proxies=None, verify=False,
+                              debug=0, max_retries=3, max_delay=1.0, max_backoff=0.10):
         """ Create Session: create a HTTP session to a server
 
         `url` Base url of the server
@@ -262,11 +267,11 @@ class RequestsKeywords(object):
         """
         digest_auth = requests.auth.HTTPDigestAuth(*auth) if auth else None
         return self._create_session(alias, url, headers, cookies, digest_auth,
-                        timeout, proxies, verify, debug, max_retries, max_delay, max_backoff)
+                                    timeout, proxies, verify, debug, max_retries, max_delay, max_backoff)
 
     def delete_all_sessions(self):
         """ Removes all the session objects """
-        logger.info ('Delete All Sessions')
+        logger.info('Delete All Sessions')
 
         self._cache.empty_cache()
 
@@ -281,8 +286,8 @@ class RequestsKeywords(object):
             json_ = self._json_pretty_print(content)
         else:
             json_ = json.loads(content)
-        logger.info ('To JSON using : content=%s ' % (content))
-        logger.info ('To JSON using : pretty_print=%s ' % (pretty_print))
+        logger.info('To JSON using : content=%s ' % (content))
+        logger.info('To JSON using : pretty_print=%s ' % (pretty_print))
 
         return json_
 
@@ -307,9 +312,9 @@ class RequestsKeywords(object):
         try:
             response = self._get_request(session, uri, headers, params, redir, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
-        logger.info ('Get Request using : alias=%s, uri=%s, headers=%s ' % (alias, uri, headers))
+        logger.info('Get Request using : alias=%s, uri=%s, headers=%s ' % (alias, uri, headers))
 
         return response
 
@@ -335,7 +340,7 @@ class RequestsKeywords(object):
         try:
             response = self._get_request(session, uri, headers, params, redir, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
         return response
 
@@ -368,8 +373,8 @@ class RequestsKeywords(object):
         try:
             response = self._post_request(session, uri, data, headers, files, redir, params, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
-        logger.info ('Post Request using : alias=%s, uri=%s, data=%s, \
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
+        logger.info('Post Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, files=%s, allow_redirects=%s ' \
                     % (alias, uri, data, headers, files, redir))
 
@@ -403,7 +408,7 @@ class RequestsKeywords(object):
         try:
             response = self._post_request(session, uri, data, headers, files, redir, timeout=timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
         return response
 
@@ -436,8 +441,8 @@ class RequestsKeywords(object):
         try:
             response = self._patch_request(session, uri, data, headers, files, redir, params, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
-        logger.info ('Patch Request using : alias=%s, uri=%s, data=%s, \
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
+        logger.info('Patch Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, files=%s, allow_redirects=%s ' \
                     % (alias, uri, data, headers, files, redir))
 
@@ -471,7 +476,7 @@ class RequestsKeywords(object):
         try:
             response = self._patch_request(session, uri, data, headers, files, redir, timeout=timeout)
         except:
-           raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
         return response
 
     @retry(RetryException, logger)
@@ -493,8 +498,8 @@ class RequestsKeywords(object):
         try:
             response = self._put_request(session, uri, data, headers, redir, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
-        logger.info ('Put Request using : alias=%s, uri=%s, data=%s, \
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
+        logger.info('Put Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, allow_redirects=%s ' % (alias, uri, data, headers, redir))
 
         return response
@@ -521,7 +526,7 @@ class RequestsKeywords(object):
         try:
             response = self._put_request(session, uri, data, headers, redir, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
         return response
 
@@ -543,9 +548,9 @@ class RequestsKeywords(object):
         try:
             redir = True if allow_redirects is None else allow_redirects
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
         response = self._delete_request(session, uri, data, headers, redir, timeout)
-        logger.info ('Delete Request using : alias=%s, uri=%s, data=%s, \
+        logger.info('Delete Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, allow_redirects=%s ' % (alias, uri, data, headers, redir))
 
         return response
@@ -572,10 +577,9 @@ class RequestsKeywords(object):
         try:
             response = self._delete_request(session, uri, data, headers, redir, timeout)
         except:
-            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
+            raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
         return response
-
 
     def head_request(self, alias, uri, headers=None, allow_redirects=None):
         """ Send a HEAD request on the session object found using the
@@ -594,7 +598,6 @@ class RequestsKeywords(object):
         allow_redirects=%s ' % (alias, uri, headers, redir))
 
         return response
-
 
     def head(self, alias, uri, headers=None, allow_redirects=None, timeout=None):
         """ * * *   Deprecated- See Head Request now   * * *
@@ -615,7 +618,6 @@ class RequestsKeywords(object):
 
         return response
 
-
     def options_request(self, alias, uri, headers=None, allow_redirects=None):
         """ Send an OPTIONS request on the session object found using the
         given `alias`
@@ -629,11 +631,10 @@ class RequestsKeywords(object):
         session = self._cache.switch(alias)
         redir = True if allow_redirects is None else allow_redirects
         response = self._options_request(session, uri, headers, redir)
-        logger.info ('Options Request using : alias=%s, uri=%s, headers=%s, allow_redirects=%s '
-                        % (alias, uri, headers, redir))
+        logger.info('Options Request using : alias=%s, uri=%s, headers=%s, allow_redirects=%s '
+                    % (alias, uri, headers, redir))
 
         return response
-
 
     def options(self, alias, uri, headers=None, allow_redirects=None):
         """ * * *   Deprecated- See Options Request now   * * *
@@ -653,7 +654,6 @@ class RequestsKeywords(object):
 
         return response
 
-
     def _get_request(self, session, uri, headers, params, allow_redirects, timeout=None):
         if timeout:
             self.timeout = float(timeout)
@@ -661,8 +661,8 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.get(self._get_url(session, uri),
                                headers=headers,
                                params=params,
@@ -691,14 +691,14 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.post(self._get_url(session, uri),
-                            data=data, headers=headers,
-                            files=files,
-                            params=params,
-                            cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                                data=data, headers=headers,
+                                files=files,
+                                params=params,
+                                cookies=self.cookies, timeout=self.timeout,
+                                allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -706,11 +706,11 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.post(self._get_url(session, uri),
-                            data=data, headers=headers,
-                            files=files,
-                            params=params,
-                            cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                                data=data, headers=headers,
+                                files=files,
+                                params=params,
+                                cookies=self.cookies, timeout=self.timeout,
+                                allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
@@ -724,14 +724,14 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.patch(self._get_url(session, uri),
-                            data=data, headers=headers,
-                            files=files,
-                            params=params,
-                            cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                                 data=data, headers=headers,
+                                 files=files,
+                                 params=params,
+                                 cookies=self.cookies, timeout=self.timeout,
+                                 allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -739,11 +739,11 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.patch(self._get_url(session, uri),
-                            data=data, headers=headers,
-                            files=files,
-                            params=params,
-                            cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                                 data=data, headers=headers,
+                                 files=files,
+                                 params=params,
+                                 cookies=self.cookies, timeout=self.timeout,
+                                 allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
@@ -757,12 +757,12 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.put(self._get_url(session, uri),
-                           data=data, headers=headers,
-                           cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                               data=data, headers=headers,
+                               cookies=self.cookies, timeout=self.timeout,
+                               allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -770,9 +770,9 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.put(self._get_url(session, uri),
-                           data=data, headers=headers,
-                           cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)
+                               data=data, headers=headers,
+                               cookies=self.cookies, timeout=self.timeout,
+                               allow_redirects=allow_redirects)
 
         self.builtin.log("PUT response: %s DEBUG" % resp.content)
         # store the last response object
@@ -786,12 +786,12 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.delete(self._get_url(session, uri), data=data,
-                              headers=headers, cookies=self.cookies,
-                              timeout=self.timeout,
-                              allow_redirects=allow_redirects)
+                                  headers=headers, cookies=self.cookies,
+                                  timeout=self.timeout,
+                                  allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -799,9 +799,9 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.delete(self._get_url(session, uri), data=data,
-                              headers=headers, cookies=self.cookies,
-                              timeout=self.timeout,
-                              allow_redirects=allow_redirects)
+                                  headers=headers, cookies=self.cookies,
+                                  timeout=self.timeout,
+                                  allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
@@ -814,11 +814,11 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.head(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)
+                                cookies=self.cookies, timeout=self.timeout,
+                                allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -826,8 +826,8 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.head(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)
+                                cookies=self.cookies, timeout=self.timeout,
+                                allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
@@ -840,11 +840,11 @@ class RequestsKeywords(object):
             self.timeout = float(self.timeout)
 
         if self.debug >= 1:
-            http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection
+            http_log = WritableObject()  # A writable object
+            sys.stdout = http_log  # Redirection
             resp = session.options(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)
+                                   cookies=self.cookies, timeout=self.timeout,
+                                   allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
@@ -852,13 +852,12 @@ class RequestsKeywords(object):
             self.builtin.log(debug_info, 'DEBUG')
         else:
             resp = session.options(self._get_url(session, uri), headers=headers,
-                            cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)
+                                   cookies=self.cookies, timeout=self.timeout,
+                                   allow_redirects=allow_redirects)
 
         # store the last response object
         session.last_resp = resp
         return resp
-
 
     def _get_url(self, session, uri):
         ''' Helper method to get the full url
@@ -866,9 +865,8 @@ class RequestsKeywords(object):
         url = session.url
         if uri:
             slash = '' if uri.startswith('/') else '/'
-            url = "%s%s%s" %(session.url, slash, uri)
+            url = "%s%s%s" % (session.url, slash, uri)
         return url
-
 
     def _json_pretty_print(self, content):
         """ Pretty print a JSON object
@@ -877,7 +875,6 @@ class RequestsKeywords(object):
         """
         temp = json.loads(content)
         return json.dumps(temp, sort_keys=True, indent=4, separators=(',', ': '))
-
 
     def _format_data_according_to_header(self, data, headers):
         if headers is not None and 'Content-Type' in headers:

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -78,7 +78,7 @@ class RequestsKeywords(object):
         s.verify = self.builtin.convert_to_boolean(verify)
 
         # cant pass these into the Session anymore
-        self.timeout = float(timeout)
+        self.timeout = float(timeout) if timeout is not None else None
         self.cookies = cookies
         self.verify = verify
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -42,8 +42,6 @@ class RequestsKeywords(object):
         self.builtin = BuiltIn()
         self.debug = 0
         self.max_retries = 0
-        self.max_delay = 0.0
-        self.max_backoff = 0.0
 
     def _utf8_urlencode(self, data):
         if type(data) is unicode:

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -31,12 +31,12 @@ def retry(ExceptionToCheck, logger=None):
     Retry calling the decorated function using an exponential backoff.
     """
     def deco_retry(f):
-        def f_retry(self, *args, **kwargs):                       
+        def f_retry(self, *args, **kwargs):
             mretries, mdelay, mbackoff = self.mretries, self.mdelay, self.mbackoff
             while mretries >= 1:
                 try:
                     return f(self, *args, **kwargs)
-                except ExceptionToCheck as e:                    
+                except ExceptionToCheck as e:
                     half_interval = mdelay * mbackoff #interval size
                     actual_delay = random.uniform(mdelay - half_interval, mdelay + half_interval)
                     msg = "%s, Retrying in %.2f seconds ..." % (str(e), actual_delay)
@@ -66,16 +66,16 @@ class WritableObject:
         self.content.append(string)
 
 class RequestsKeywords(object):
-    ROBOT_LIBRARY_SCOPE = 'Global'    
+    ROBOT_LIBRARY_SCOPE = 'Global'
 
     def __init__(self):
         self._cache = robot.utils.ConnectionCache('No sessions created')
-        self.builtin = BuiltIn()        
+        self.builtin = BuiltIn()
         self.debug = 0
         self.mretries = 0
         self.mdelay = 0.0
         self.mbackoff = 0.0
-        
+
     def _utf8_urlencode(self, data):
         if type(data) is unicode:
             return data.encode('utf-8')
@@ -114,12 +114,12 @@ class RequestsKeywords(object):
         
         `max_delay` The maximum number of delay each connection should attempt.
         """
-        
+
         # Type casting since robot vars unicode
         self.mretries = int(max_retries)
         self.mdelay = float(max_delay)
         self.mbackoff = float(max_backoff)
-        
+
         self.builtin.log('Creating session: %s' % alias, 'DEBUG')
         s = session = requests.Session()
         s.headers.update(headers)
@@ -127,7 +127,7 @@ class RequestsKeywords(object):
         s.proxies = proxies if proxies else  s.proxies
 
         s.verify = self.builtin.convert_to_boolean(verify)
-        
+
         # cant pass these into the Session anymore
         self.timeout = timeout
         self.cookies = cookies
@@ -136,12 +136,12 @@ class RequestsKeywords(object):
         # cant use hooks :(
         self.host = urlparse.urlparse(url).netloc
         s.url = url
-        
+
         # Enable http verbosity
-        if debug >= 1:            
+        if debug >= 1:
             self.debug = int(debug)
             httplib.HTTPConnection.debuglevel = self.debug
-        
+
         self._cache.register(session, alias=alias)
         return session
 
@@ -175,11 +175,11 @@ class RequestsKeywords(object):
         
         `max_backoff` Expoential backoff
         """
-        auth = requests.auth.HTTPBasicAuth(*auth) if auth else None        
-            
+        auth = requests.auth.HTTPBasicAuth(*auth) if auth else None
+
         logger.info('Creating Session using : alias=%s, url=%s, headers=%s, \
                     cookies=%s, auth=%s, timeout=%s, proxies=%s, verify=%s, \
-                    debug=%s ' % (alias, url, headers, cookies, auth, timeout, 
+                    debug=%s ' % (alias, url, headers, cookies, auth, timeout,
                                   proxies, verify, debug))
         return self._create_session(alias, url, headers, cookies, auth,
                                     timeout, proxies, verify, debug, max_retries, max_delay, max_backoff)
@@ -228,12 +228,12 @@ class RequestsKeywords(object):
                         % (alias, url, headers, cookies, ntlm_auth, \
                         timeout, proxies, verify, debug))
             return self._create_session(alias, url, headers, cookies,
-                                        ntlm_auth, timeout, proxies, verify, 
+                                        ntlm_auth, timeout, proxies, verify,
                                         debug, max_retries, max_delay, max_backoff)
 
 
-    def create_digest_session(self, alias, url, auth, headers={}, cookies=None, 
-                                timeout=None, proxies=None, verify=False, 
+    def create_digest_session(self, alias, url, auth, headers={}, cookies=None,
+                                timeout=None, proxies=None, verify=False,
                                 debug=0, max_retries=3, max_delay=1.0, max_backoff=0.10):
         """ Create Session: create a HTTP session to a server
 
@@ -261,9 +261,9 @@ class RequestsKeywords(object):
         `max_backoff` Expoential backoff
         """
         digest_auth = requests.auth.HTTPDigestAuth(*auth) if auth else None
-        return self._create_session(alias, url, headers, cookies, digest_auth, 
+        return self._create_session(alias, url, headers, cookies, digest_auth,
                         timeout, proxies, verify, debug, max_retries, max_delay, max_backoff)
-    
+
     def delete_all_sessions(self):
         """ Removes all the session objects """
         logger.info ('Delete All Sessions')
@@ -285,7 +285,7 @@ class RequestsKeywords(object):
         logger.info ('To JSON using : pretty_print=%s ' % (pretty_print))
 
         return json_
-    
+
     @retry(RetryException, logger)
     def get_request(self, alias, uri, headers=None, params={}, allow_redirects=None, timeout=None):
         """ Send a GET request on the session object found using the
@@ -295,18 +295,20 @@ class RequestsKeywords(object):
 
         `uri` to send the GET request to
 
+        `params` url parameters to append to the uri
+
         `headers` a dictionary of headers to use with the request
         
         `timeout` connection timeout
-        """        
+        """
         session = self._cache.switch(alias)
         params = self._utf8_urlencode(params)
         redir = True if allow_redirects is None else allow_redirects
-        try:            
+        try:
             response = self._get_request(session, uri, headers, params, redir, timeout)
-        except:                        
+        except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
-        
+
         logger.info ('Get Request using : alias=%s, uri=%s, headers=%s ' % (alias, uri, headers))
 
         return response
@@ -325,7 +327,7 @@ class RequestsKeywords(object):
         `headers` a dictionary of headers to use with the request
         
         `timeout` connection timeout
-        """        
+        """
         print "Deprication Warning  Use Get Request in the future"
         session = self._cache.switch(alias)
         params = self._utf8_urlencode(params)
@@ -338,7 +340,7 @@ class RequestsKeywords(object):
         return response
 
     @retry(RetryException, logger)
-    def post_request(self, alias, uri, data={}, headers=None, files={}, allow_redirects=None, timeout=None):
+    def post_request(self, alias, uri, data={}, headers=None, files={}, allow_redirects=None, params={}, timeout=None):
         """ Send a POST request on the session object found using the
         given `alias`
 
@@ -355,13 +357,13 @@ class RequestsKeywords(object):
         `files` a dictionary of file names containing file data to POST to the server
         
         `timeout` connection timeout
-        """        
+        """
         session = self._cache.switch(alias)
         data = self._format_data_according_to_header(data, headers)
         redir = True if allow_redirects is None else allow_redirects
-        try:            
-            response = self._post_request(session, uri, data, headers, files, redir, timeout)
-        except:                        
+        try:
+            response = self._post_request(session, uri, data, headers, files, redir, params, timeout)
+        except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
         logger.info ('Post Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, files=%s, allow_redirects=%s ' \
@@ -395,14 +397,14 @@ class RequestsKeywords(object):
         data = self._utf8_urlencode(data)
         redir = True if allow_redirects is None else allow_redirects
         try:
-            response = self._post_request(session, uri, data, headers, files, redir, timeout)
+            response = self._post_request(session, uri, data, headers, files, redir, timeout=timeout)
         except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
 
         return response
 
     @retry(RetryException, logger)
-    def patch_request(self, alias, uri, data={}, headers=None, files={}, allow_redirects=None, timeout=None):
+    def patch_request(self, alias, uri, data={}, headers=None, files={}, allow_redirects=None, params={}, timeout=None):
         """ Send a PATCH request on the session object found using the
         given `alias`
 
@@ -423,8 +425,8 @@ class RequestsKeywords(object):
         session = self._cache.switch(alias)
         data = self._format_data_according_to_header(data, headers)
         redir = True if allow_redirects is None else allow_redirects
-        try:            
-            response = self._patch_request(session, uri, data, headers, files, redir, timeout)
+        try:
+            response = self._patch_request(session, uri, data, headers, files, redir, params, timeout)
         except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
         logger.info ('Patch Request using : alias=%s, uri=%s, data=%s, \
@@ -458,9 +460,9 @@ class RequestsKeywords(object):
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
         redir = True if allow_redirects is None else allow_redirects
-        try:            
-            response = self._patch_request(session, uri, data, headers, files, redir, timeout)
-        except:                        
+        try:
+            response = self._patch_request(session, uri, data, headers, files, redir, timeout=timeout)
+        except:
            raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
         return response
 
@@ -480,9 +482,9 @@ class RequestsKeywords(object):
         session = self._cache.switch(alias)
         data = self._format_data_according_to_header(data, headers)
         redir = True if allow_redirects is None else allow_redirects
-        try:            
+        try:
             response = self._put_request(session, uri, data, headers, redir, timeout)
-        except:            
+        except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
         logger.info ('Put Request using : alias=%s, uri=%s, data=%s, \
                     headers=%s, allow_redirects=%s ' % (alias, uri, data, headers, redir))
@@ -527,12 +529,12 @@ class RequestsKeywords(object):
         `headers` a dictionary of headers to use with the request
         
         `timeout` connection timeout
-        """        
+        """
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
-        try:            
+        try:
             redir = True if allow_redirects is None else allow_redirects
-        except:            
+        except:
             raise RetryException("host=" + self.host + " uri: "+ uri + " not responding")
         response = self._delete_request(session, uri, data, headers, redir, timeout)
         logger.info ('Delete Request using : alias=%s, uri=%s, data=%s, \
@@ -554,7 +556,7 @@ class RequestsKeywords(object):
         `headers` a dictionary of headers to use with the request
         
         `timeout` connection timeout
-        """        
+        """
         print "Deprication Warning  Use Delete Request in the future"
         session = self._cache.switch(alias)
         data = self._utf8_urlencode(data)
@@ -576,7 +578,7 @@ class RequestsKeywords(object):
         `uri` to send the HEAD request to
 
         `headers` a dictionary of headers to use with the request
-        """        
+        """
         session = self._cache.switch(alias)
         redir = False if allow_redirects is None else allow_redirects
         response = self._head_request(session, uri, headers, redir)
@@ -597,7 +599,7 @@ class RequestsKeywords(object):
         `uri` to send the HEAD request to
 
         `headers` a dictionary of headers to use with the request
-        """        
+        """
         print "Deprication Warning  Use Head Request in the future"
         session = self._cache.switch(alias)
         redir = False if allow_redirects is None else allow_redirects
@@ -615,13 +617,13 @@ class RequestsKeywords(object):
         `uri` to send the OPTIONS request to
 
         `headers` a dictionary of headers to use with the request
-        """        
+        """
         session = self._cache.switch(alias)
         redir = True if allow_redirects is None else allow_redirects
         response = self._options_request(session, uri, headers, redir)
-        logger.info ('Options Request using : alias=%s, uri=%s, headers=%s, allow_redirects=%s ' 
+        logger.info ('Options Request using : alias=%s, uri=%s, headers=%s, allow_redirects=%s '
                         % (alias, uri, headers, redir))
-        
+
         return response
 
 
@@ -642,28 +644,28 @@ class RequestsKeywords(object):
         response = self._options_request(session, uri, headers, redir)
 
         return response
-    
-    
-    def _get_request(self, session, uri, headers, params, allow_redirects, timeout=None):        
+
+
+    def _get_request(self, session, uri, headers, params, allow_redirects, timeout=None):
         if timeout:
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-        
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection            
+            sys.stdout = http_log   # Redirection
             resp = session.get(self._get_url(session, uri),
                                headers=headers,
                                params=params,
                                cookies=self.cookies, timeout=self.timeout,
-                               allow_redirects=allow_redirects)            
+                               allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
             # Remove empty lines
             debug_info = "\n".join([ll.rstrip() for ll in debug_info.splitlines() if ll.strip()])
             self.builtin.log(debug_info, 'DEBUG')
-        else:            
+        else:
             resp = session.get(self._get_url(session, uri),
                                headers=headers,
                                params=params,
@@ -671,21 +673,22 @@ class RequestsKeywords(object):
                                allow_redirects=allow_redirects)
 
         # store the last response object
-        session.last_resp = resp                
+        session.last_resp = resp
         return resp
 
-    def _post_request(self, session, uri, data, headers, files, allow_redirects, timeout=None):
+    def _post_request(self, session, uri, data, headers, files, allow_redirects, params=None, timeout=None):
         if timeout:
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-        
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection     
+            sys.stdout = http_log   # Redirection
             resp = session.post(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
+                            params=params,
                             cookies=self.cookies, timeout=self.timeout,
                            allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
@@ -693,30 +696,32 @@ class RequestsKeywords(object):
             # Remove empty lines
             debug_info = "\n".join([ll.rstrip() for ll in debug_info.splitlines() if ll.strip()])
             self.builtin.log(debug_info, 'DEBUG')
-        else:            
+        else:
             resp = session.post(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
+                            params=params,
                             cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)        
-        
+                           allow_redirects=allow_redirects)
+
         # store the last response object
-        session.last_resp = resp        
+        session.last_resp = resp
         self.builtin.log("Post response: " + resp.content, 'DEBUG')
         return resp
 
-    def _patch_request(self, session, uri, data, headers, files, allow_redirects, timeout=None):
+    def _patch_request(self, session, uri, data, headers, files, allow_redirects, params=None, timeout=None):
         if timeout:
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-        
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection            
+            sys.stdout = http_log   # Redirection
             resp = session.patch(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
+                            params=params,
                             cookies=self.cookies, timeout=self.timeout,
                            allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
@@ -724,27 +729,28 @@ class RequestsKeywords(object):
             # Remove empty lines
             debug_info = "\n".join([ll.rstrip() for ll in debug_info.splitlines() if ll.strip()])
             self.builtin.log(debug_info, 'DEBUG')
-        else:            
+        else:
             resp = session.patch(self._get_url(session, uri),
                             data=data, headers=headers,
                             files=files,
+                            params=params,
                             cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)        
-        
+                           allow_redirects=allow_redirects)
+
         # store the last response object
-        session.last_resp = resp        
+        session.last_resp = resp
         self.builtin.log("Patch response: " + resp.content, 'DEBUG')
         return resp
 
-    def _put_request(self, session, uri, data, headers, allow_redirects, timeout=None):
+    def _put_request(self, session, uri, data, headers, allow_redirects, params=None, timeout=None):
         if timeout:
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-        
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection            
+            sys.stdout = http_log   # Redirection
             resp = session.put(self._get_url(session, uri),
                            data=data, headers=headers,
                            cookies=self.cookies, timeout=self.timeout,
@@ -758,8 +764,8 @@ class RequestsKeywords(object):
             resp = session.put(self._get_url(session, uri),
                            data=data, headers=headers,
                            cookies=self.cookies, timeout=self.timeout,
-                           allow_redirects=allow_redirects)        
-        
+                           allow_redirects=allow_redirects)
+
         self.builtin.log("PUT response: %s DEBUG" % resp.content)
         # store the last response object
         session.last_resp = resp
@@ -770,10 +776,10 @@ class RequestsKeywords(object):
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-            
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection             
+            sys.stdout = http_log   # Redirection
             resp = session.delete(self._get_url(session, uri), data=data,
                               headers=headers, cookies=self.cookies,
                               timeout=self.timeout,
@@ -783,12 +789,12 @@ class RequestsKeywords(object):
             # Remove empty lines
             debug_info = "\n".join([ll.rstrip() for ll in debug_info.splitlines() if ll.strip()])
             self.builtin.log(debug_info, 'DEBUG')
-        else:            
+        else:
             resp = session.delete(self._get_url(session, uri), data=data,
                               headers=headers, cookies=self.cookies,
                               timeout=self.timeout,
                               allow_redirects=allow_redirects)
-                              
+
         # store the last response object
         session.last_resp = resp
         return resp
@@ -798,10 +804,10 @@ class RequestsKeywords(object):
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-        
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection        
+            sys.stdout = http_log   # Redirection
             resp = session.head(self._get_url(session, uri), headers=headers,
                             cookies=self.cookies, timeout=self.timeout,
                             allow_redirects=allow_redirects)
@@ -813,8 +819,8 @@ class RequestsKeywords(object):
         else:
             resp = session.head(self._get_url(session, uri), headers=headers,
                             cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)        
-        
+                            allow_redirects=allow_redirects)
+
         # store the last response object
         session.last_resp = resp
         return resp
@@ -824,10 +830,10 @@ class RequestsKeywords(object):
             self.timeout = float(timeout)
         elif self.timeout:
             self.timeout = float(self.timeout)
-            
+
         if self.debug >= 1:
             http_log = WritableObject() # A writable object
-            sys.stdout = http_log   # Redirection            
+            sys.stdout = http_log   # Redirection
             resp = session.options(self._get_url(session, uri), headers=headers,
                             cookies=self.cookies, timeout=self.timeout,
                             allow_redirects=allow_redirects)
@@ -839,10 +845,10 @@ class RequestsKeywords(object):
         else:
             resp = session.options(self._get_url(session, uri), headers=headers,
                             cookies=self.cookies, timeout=self.timeout,
-                            allow_redirects=allow_redirects)            
-        
+                            allow_redirects=allow_redirects)
+
         # store the last response object
-        session.last_resp = resp        
+        session.last_resp = resp
         return resp
 
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -355,7 +355,11 @@ class RequestsKeywords(object):
         `headers` a dictionary of headers to use with the request
 
         `files` a dictionary of file names containing file data to POST to the server
-        
+
+        `allow_redirects` requests redirection
+
+        `params` url parameters to append to the uri
+
         `timeout` connection timeout
         """
         session = self._cache.switch(alias)
@@ -419,6 +423,10 @@ class RequestsKeywords(object):
         `headers` a dictionary of headers to use with the request
 
         `files` a dictionary of file names containing file data to PATCH to the server
+
+        `allow_redirects` requests redirection
+
+        `params` url parameters to append to the uri
         
         `timeout` connection timeout
         """

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -3,7 +3,6 @@ import json
 import sys
 import logging
 import httplib
-import urlparse
 
 from urllib import urlencode
 from requests.auth import HTTPDigestAuth
@@ -81,8 +80,6 @@ class RequestsKeywords(object):
         self.cookies = cookies
         self.verify = verify
 
-        # cant use hooks :(
-        self.host = urlparse.urlparse(url).netloc
         s.url = url
 
         # Enable http verbosity

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -412,7 +412,8 @@ class RequestsKeywords(object):
 
         return response
 
-    def put_request(self, alias, uri, data=None, params=None, files=None, headers=None, allow_redirects=None, timeout=None):
+    def put_request(self, alias, uri, data=None, params=None, files=None, headers=None, allow_redirects=None,
+                    timeout=None):
         """ Send a PUT request on the session object found using the
         given `alias`
 
@@ -592,8 +593,8 @@ class RequestsKeywords(object):
                            cookies=self.cookies)
 
         self._print_debug()
-        # store the last response object
-        session.last_resp = resp
+        session.last_resp = resp  # Store the last session object (@Kosuri Why?)
+
         return resp
 
     def _body_request(self, method_name, session, uri, data, params, files, headers, allow_redirects, timeout):

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -5,11 +5,9 @@ import sys
 import logging
 import httplib
 import urlparse
-# import vcr
 
 from urllib import urlencode
 from requests.auth import HTTPDigestAuth
-from requests.exceptions import RequestException
 
 import robot
 from robot.libraries.BuiltIn import BuiltIn
@@ -19,9 +17,6 @@ try:
     from requests_ntlm import HttpNtlmAuth
 except ImportError:
     pass
-
-from functools import wraps
-import time
 
 
 class WritableObject:
@@ -83,7 +78,7 @@ class RequestsKeywords(object):
         s.verify = self.builtin.convert_to_boolean(verify)
 
         # cant pass these into the Session anymore
-        self.timeout = timeout
+        self.timeout = float(timeout)
         self.cookies = cookies
         self.verify = verify
 
@@ -157,10 +152,6 @@ class RequestsKeywords(object):
                 https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_debuglevel
         
         `max_retries` The maximum number of retries each connection should attempt.
-        
-        `max_delay` The maximum number of delay each connection should attempt.
-        
-        `max_backoff` Expoential backoff
         """
         if not HttpNtlmAuth:
             raise AssertionError('Requests NTLM module not loaded')
@@ -202,10 +193,6 @@ class RequestsKeywords(object):
                 https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_debuglevel
         
         `max_retries` The maximum number of retries each connection should attempt.
-        
-        `max_delay` The maximum number of delay each connection should attempt.
-        
-        `max_backoff` Expoential backoff
         """
         digest_auth = requests.auth.HTTPDigestAuth(*auth) if auth else None
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -43,18 +43,6 @@ class RequestsKeywords(object):
         self.debug = 0
         self.max_retries = 0
 
-    def _utf8_urlencode(self, data):
-        if type(data) is unicode:
-            return data.encode('utf-8')
-
-        if not type(data) is dict:
-            return data
-
-        utf8_data = {}
-        for k, v in data.iteritems():
-            utf8_data[k] = unicode(v).encode('utf-8')
-        return urlencode(utf8_data)
-
     def _create_session(self, alias, url, headers, cookies, auth,
                         timeout, proxies, verify, debug, max_retries, max_delay, max_backoff):
 
@@ -84,8 +72,6 @@ class RequestsKeywords(object):
 
         # Type casting since robot vars unicode
         self.max_retries = int(max_retries)
-        self.max_delay = float(max_delay)
-        self.max_backoff = float(max_backoff)
 
         self.builtin.log('Creating session: %s' % alias, 'DEBUG')
         s = session = requests.Session()
@@ -715,6 +701,18 @@ class RequestsKeywords(object):
         """
         temp = json.loads(content)
         return json.dumps(temp, sort_keys=True, indent=4, separators=(',', ': '))
+
+    def _utf8_urlencode(self, data):
+        if type(data) is unicode:
+            return data.encode('utf-8')
+
+        if not type(data) is dict:
+            return data
+
+        utf8_data = {}
+        for k, v in data.iteritems():
+            utf8_data[k] = unicode(v).encode('utf-8')
+        return urlencode(utf8_data)
 
     def _format_data_according_to_header(self, data, headers):
         if headers is not None and 'Content-Type' in headers:

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -1,5 +1,4 @@
 import requests
-import random
 import json
 import sys
 import logging
@@ -236,7 +235,6 @@ class RequestsKeywords(object):
         `timeout` connection timeout
         """
         session = self._cache.switch(alias)
-        params = self._utf8_urlencode(params)
         redir = True if allow_redirects is None else allow_redirects
 
         response = self._get_request(session, uri, params, headers, redir, timeout)
@@ -261,9 +259,6 @@ class RequestsKeywords(object):
         """
         print "Deprication Warning  Use Get Request in the future"
         session = self._cache.switch(alias)
-
-        if params:
-            params = self._utf8_urlencode(params)
 
         redir = True if allow_redirects is None else allow_redirects
 
@@ -574,7 +569,7 @@ class RequestsKeywords(object):
 
         resp = session.get(self._get_url(session, uri),
                            headers=headers,
-                           params=params,
+                           params=self._utf8_urlencode(params),
                            allow_redirects=allow_redirects,
                            timeout=self._get_timeout(timeout),
                            cookies=self.cookies)
@@ -590,7 +585,7 @@ class RequestsKeywords(object):
         method = getattr(session, method_name)
         resp = method(self._get_url(session, uri),
                       data=data,
-                      params=params,
+                      params=self._utf8_urlencode(params),
                       files=files,
                       headers=headers,
                       allow_redirects=allow_redirects,
@@ -609,7 +604,7 @@ class RequestsKeywords(object):
 
         resp = session.delete(self._get_url(session, uri),
                               data=data,
-                              params=params,
+                              params=self._utf8_urlencode(params),
                               headers=headers,
                               allow_redirects=allow_redirects,
                               timeout=self._get_timeout(timeout),

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -480,7 +480,7 @@ class RequestsKeywords(object):
         return response
 
     @retry(RetryException, logger)
-    def put_request(self, alias, uri, data=None, headers=None, allow_redirects=None, timeout=None):
+    def put_request(self, alias, uri, data=None, headers=None, allow_redirects=None, params={}, timeout=None):
         """ Send a PUT request on the session object found using the
         given `alias`
 
@@ -490,13 +490,17 @@ class RequestsKeywords(object):
 
         `headers` a dictionary of headers to use with the request
 
+        `allow_redirects` requests redirection
+
+        `params` url parameters to append to the uri
+
         `timeout` connection timeout
         """
         session = self._cache.switch(alias)
         data = self._format_data_according_to_header(data, headers)
         redir = True if allow_redirects is None else allow_redirects
         try:
-            response = self._put_request(session, uri, data, headers, redir, timeout)
+            response = self._put_request(session, uri, data, headers, redir, params, timeout)
         except:
             raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
         logger.info('Put Request using : alias=%s, uri=%s, data=%s, \
@@ -524,7 +528,7 @@ class RequestsKeywords(object):
         data = self._utf8_urlencode(data)
         redir = True if allow_redirects is None else allow_redirects
         try:
-            response = self._put_request(session, uri, data, headers, redir, timeout)
+            response = self._put_request(session, uri, data, headers, redir, timeout=timeout)
         except:
             raise RetryException("host=" + self.host + " uri: " + uri + " not responding")
 
@@ -761,7 +765,9 @@ class RequestsKeywords(object):
             sys.stdout = http_log  # Redirection
             resp = session.put(self._get_url(session, uri),
                                data=data, headers=headers,
-                               cookies=self.cookies, timeout=self.timeout,
+                               cookies=self.cookies,
+                               params=params,
+                               timeout=self.timeout,
                                allow_redirects=allow_redirects)
             sys.stdout = sys.__stdout__  # Remember to reset sys.stdout!
             debug_info = ''.join(http_log.content).replace('\\r', '').decode('string_escape').replace('\'', '')
@@ -771,7 +777,9 @@ class RequestsKeywords(object):
         else:
             resp = session.put(self._get_url(session, uri),
                                data=data, headers=headers,
-                               cookies=self.cookies, timeout=self.timeout,
+                               cookies=self.cookies,
+                               params=params,
+                               timeout=self.timeout,
                                allow_redirects=allow_redirects)
 
         self.builtin.log("PUT response: %s DEBUG" % resp.content)


### PR DESCRIPTION
This pull requests is a response to perceived source decay. Its mostly de-duplication and cleanup but I also had to revert a few things @vkosuri did.

Here is a breakdown of what I've done and why:

**1 - Removed retry decorator**
I remove it because of two reasons. Firstly because it was not very fast and it was implemented using a hard sleep. Also requests already supports adapter level max_retries. Secondly, the decorator would break Robotframework's parameter translation, which in turn made it impossible to use strings containing the equal symbol as it would be interpreted as a keyword argument.

**2- Removed overly broad catch around requests calls**
It would cause every exception to be interpreted as a retry exception. Also its not necessary, we want requests exceptions to reach the framework if possible.

**3- Deduplication**
A lost of the debug code was just copy pasted and needed to be refactored.

**4- Made arguments optional again**
Because it broke backward compatibility.

Also @bulkan if you want help with code reviews and maintenance, me and my employers would gladly help around if you provided us with collaborator access :)

Closes #84 
Closes #83
Includes #85