### PR TITLE
Python3 removes execfile, work around this by manually opening the fi…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 from distutils.core import setup
 
 from os.path import abspath, dirname, join
-execfile(join(dirname(abspath(__file__)), 'src', 'RequestsLibrary', 'version.py'))
+
+with open(join(dirname(abspath(__file__)), 'src', 'RequestsLibrary', 'version.py')) as f:
+    code = compile(f.read(), "version.py", 'exec')
+    exec(code)
 
 DESCRIPTION = """
 Robot Framework keyword library wrapper around the HTTP client library requests.


### PR DESCRIPTION
…le, reading, compiling and then execing the code this is for issue #109