### PR TITLE
Fix bug #111 Create Session kw prints Arg type

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -80,7 +80,10 @@ class RequestsKeywords(object):
         s.auth = auth if auth else s.auth
         s.proxies = proxies if proxies else s.proxies
 
-        max_retries = self.builtin._convert_to_integer(max_retries)        
+        try:
+            max_retries = int(max_retries)
+        except ValueError as err:
+            raise ValueError("Error converting max_retries parameter: %s"   % err)        
 
         if max_retries > 0:
             http = requests.adapters.HTTPAdapter(max_retries=Retry(total=max_retries, backoff_factor=backoff_factor))

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -80,7 +80,7 @@ class RequestsKeywords(object):
         s.auth = auth if auth else s.auth
         s.proxies = proxies if proxies else s.proxies
 
-        max_retries = self.builtin.convert_to_integer(max_retries)        
+        max_retries = int(max_retries)        
 
         if max_retries > 0:
             http = requests.adapters.HTTPAdapter(max_retries=Retry(total=max_retries, backoff_factor=backoff_factor))

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -80,7 +80,7 @@ class RequestsKeywords(object):
         s.auth = auth if auth else s.auth
         s.proxies = proxies if proxies else s.proxies
 
-        max_retries = int(max_retries)        
+        max_retries = self.builtin._convert_to_integer(max_retries)        
 
         if max_retries > 0:
             http = requests.adapters.HTTPAdapter(max_retries=Retry(total=max_retries, backoff_factor=backoff_factor))


### PR DESCRIPTION
Convert the max_retries argument to integer using native python method int(), instead of the Robot convert_to_integer keyword. This avoid that garbage message is printed to Robot logs as: Argument types are: <type 'unicode'>