### PR TITLE
added trust_env 

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -44,6 +44,7 @@ class RequestsKeywords(object):
             timeout,
             max_retries,
             backoff_factor,
+            trust_env,
             proxies,
             verify,
             debug,
@@ -78,6 +79,7 @@ class RequestsKeywords(object):
         s = session = requests.Session()
         s.headers.update(headers)
         s.auth = auth if auth else s.auth
+        s.trust_env = trust_env if trust_env else s.trust_env
         s.proxies = proxies if proxies else s.proxies
 
         try:
@@ -129,7 +131,7 @@ class RequestsKeywords(object):
         return session
 
     def create_session(self, alias, url, headers={}, cookies=None,
-                       auth=None, timeout=None, proxies=None,
+                       auth=None, timeout=None, trust_env=True, proxies=None,
                        verify=False, debug=0, max_retries=3, backoff_factor=0.10, disable_warnings=0):
         """ Create Session: create a HTTP session to a server
 
@@ -160,9 +162,9 @@ class RequestsKeywords(object):
         auth = requests.auth.HTTPBasicAuth(*auth) if auth else None
 
         logger.info('Creating Session using : alias=%s, url=%s, headers=%s, \
-                    cookies=%s, auth=%s, timeout=%s, proxies=%s, verify=%s, \
+                    cookies=%s, auth=%s, timeout=%s, trust_env=%s, proxies=%s, verify=%s, \
                     debug=%s ' % (alias, url, headers, cookies, auth, timeout,
-                                  proxies, verify, debug))
+                                  trust_env, proxies, verify, debug))
 
         return self._create_session(
             alias,
@@ -173,6 +175,7 @@ class RequestsKeywords(object):
             timeout,
             max_retries,
             backoff_factor,
+            trust_env,
             proxies,
             verify,
             debug,


### PR DESCRIPTION
This is related to issue #116  which I opend earlier. I tried to implement a suggestion from this [comment ](https://github.com/kennethreitz/requests/issues/2988#issuecomment-224599084) to be able to turn off the check  of system´s proxy setting. But it seems to have no effect - there is still a 5 second delay even if I call `Create Session` with `trust_env=False`.