### PR TITLE
pass 'verify' through to all requests

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -886,7 +886,8 @@ class RequestsKeywords(object):
                            params=self._utf8_urlencode(params),
                            allow_redirects=allow_redirects,
                            timeout=self._get_timeout(timeout),
-                           cookies=self.cookies)
+                           cookies=self.cookies,
+                           verify=self.verify)
 
         self._print_debug()
         # Store the last session object (@Kosuri Why?)
@@ -915,7 +916,8 @@ class RequestsKeywords(object):
                       headers=headers,
                       allow_redirects=allow_redirects,
                       timeout=self._get_timeout(timeout),
-                      cookies=self.cookies)
+                      cookies=self.cookies,
+                      verify=self.verify)
 
         self._print_debug()
 
@@ -943,7 +945,8 @@ class RequestsKeywords(object):
                               headers=headers,
                               allow_redirects=allow_redirects,
                               timeout=self._get_timeout(timeout),
-                              cookies=self.cookies)
+                              cookies=self.cookies,
+                              verify=self.verify)
 
         self._print_debug()
 
@@ -959,7 +962,8 @@ class RequestsKeywords(object):
                             headers=headers,
                             allow_redirects=allow_redirects,
                             timeout=self._get_timeout(timeout),
-                            cookies=self.cookies)
+                            cookies=self.cookies,
+                            verify=self.verify)
 
         self._print_debug()
 
@@ -981,7 +985,8 @@ class RequestsKeywords(object):
                                headers=headers,
                                cookies=self.cookies,
                                allow_redirects=allow_redirects,
-                               timeout=self._get_timeout(timeout))
+                               timeout=self._get_timeout(timeout),
+                               verify=self.verify)
 
         self._print_debug()
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -135,7 +135,7 @@ class RequestsKeywords(object):
         # cant pass these into the Session anymore
         self.timeout = float(timeout) if timeout is not None else None
         self.cookies = cookies
-        self.verify = verify
+        self.verify = verify if self.builtin.convert_to_boolean(verify) != True else None
 
         s.url = url
 


### PR DESCRIPTION
When making requests against a local website using self-signed certificates, we were seeing SSL verification errors despite setting `verify=False`. Passing `verify` through to all the requests fixes the issue.