### PR TITLE
Put and Post Request with Json data directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ log.html
 output.xml
 debug.txt
 report.html
+foobar.txt
 
 ~*
 htmlcov

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -639,11 +639,11 @@ class RequestsKeywords(object):
         ``uri`` to send the PUT request to
 
         ``data`` a dictionary of key-value pairs that will be urlencoded
-               and sent as POST data
+               and sent as PUT data
                or binary data that is sent as the raw body content
 
         ``json`` a value that will be json encoded
-               and sent as POST data if data is not specified
+               and sent as PUT data if data is not specified
 
         ``headers`` a dictionary of headers to use with the request
 

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -413,6 +413,7 @@ class RequestsKeywords(object):
             alias,
             uri,
             data=None,
+            json=None,
             params=None,
             headers=None,
             files=None,
@@ -430,6 +431,9 @@ class RequestsKeywords(object):
                or binary data that is sent as the raw body content
                or passed as such for multipart form data if ``files`` is also
                   defined
+
+        ``json`` a value that will be json encoded
+               and sent as POST data if files or data is not specified
 
         ``params`` url parameters to append to the uri
 
@@ -451,6 +455,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            json,
             params,
             files,
             headers,
@@ -503,6 +508,7 @@ class RequestsKeywords(object):
             uri,
             data,
             None,
+            None,
             files,
             headers,
             redir,
@@ -550,6 +556,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            None,
             params,
             files,
             headers,
@@ -605,6 +612,7 @@ class RequestsKeywords(object):
             uri,
             data,
             None,
+            None,
             files,
             headers,
             redir,
@@ -617,6 +625,7 @@ class RequestsKeywords(object):
             alias,
             uri,
             data=None,
+            json=None,
             params=None,
             files=None,
             headers=None,
@@ -628,6 +637,13 @@ class RequestsKeywords(object):
         ``alias`` that will be used to identify the Session object in the cache
 
         ``uri`` to send the PUT request to
+
+        ``data`` a dictionary of key-value pairs that will be urlencoded
+               and sent as POST data
+               or binary data that is sent as the raw body content
+
+        ``json`` a value that will be json encoded
+               and sent as POST data if data is not specified
 
         ``headers`` a dictionary of headers to use with the request
 
@@ -646,6 +662,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            json,
             params,
             files,
             headers,
@@ -692,6 +709,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            None,
             None,
             None,
             headers,
@@ -908,6 +926,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            json,
             params,
             files,
             headers,
@@ -918,6 +937,7 @@ class RequestsKeywords(object):
         method = getattr(session, method_name)
         resp = method(self._get_url(session, uri),
                       data=data,
+                      json=json,
                       params=self._utf8_urlencode(params),
                       files=files,
                       headers=headers,

--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -521,6 +521,7 @@ class RequestsKeywords(object):
             alias,
             uri,
             data=None,
+            json=None,
             params=None,
             headers=None,
             files=None,
@@ -536,6 +537,9 @@ class RequestsKeywords(object):
         ``data`` a dictionary of key-value pairs that will be urlencoded
                and sent as PATCH data
                or binary data that is sent as the raw body content
+
+        ``json`` a value that will be json encoded
+               and sent as PATCH data if data is not specified
 
         ``headers`` a dictionary of headers to use with the request
 
@@ -556,7 +560,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
-            None,
+            json,
             params,
             files,
             headers,
@@ -722,7 +726,8 @@ class RequestsKeywords(object):
             self,
             alias,
             uri,
-            data=(),
+            data=None,
+            json=None,
             params=None,
             headers=None,
             allow_redirects=None,
@@ -733,6 +738,9 @@ class RequestsKeywords(object):
         ``alias`` that will be used to identify the Session object in the cache
 
         ``uri`` to send the DELETE request to
+
+        ``json`` a value that will be json encoded
+               and sent as request data if data is not specified
 
         ``headers`` a dictionary of headers to use with the request
         
@@ -745,7 +753,7 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
 
         response = self._delete_request(
-            session, uri, data, params, headers, redir, timeout)
+            session, uri, data, json, params, headers, redir, timeout)
 
         if isinstance(data, bytes):
             data = data.decode('utf-8')
@@ -783,7 +791,7 @@ class RequestsKeywords(object):
         redir = True if allow_redirects is None else allow_redirects
 
         response = self._delete_request(
-            session, uri, data, None, headers, redir, timeout)
+            session, uri, data, json, None, headers, redir, timeout)
 
         return response
 
@@ -960,6 +968,7 @@ class RequestsKeywords(object):
             session,
             uri,
             data,
+            json,
             params,
             headers,
             allow_redirects,
@@ -968,6 +977,7 @@ class RequestsKeywords(object):
 
         resp = session.delete(self._get_url(session, uri),
                               data=data,
+                              json=json,
                               params=self._utf8_urlencode(params),
                               headers=headers,
                               allow_redirects=allow_redirects,

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -255,6 +255,15 @@ Delete Request With Data
     Comment  Dictionary Should Contain Value  ${resp.json()['data']}  bulkan
     Comment  Dictionary Should Contain Value  ${resp.json()['data']}  evcimen
 
+Delete Requests with Json Data
+    [Tags]  delete
+    Create Session  httpbin     http://httpbin.org
+    &{data}=    Create Dictionary   latitude=30.496346  longitude=-87.640356
+    ${resp}=     Delete Request  httpbin  /delete    json=${data}
+    Should Be Equal As Strings  ${resp.status_code}  200
+    ${jsondata}=  To Json  ${resp.content}
+    Should Be Equal     ${jsondata['json']}     ${data}
+
 Patch Requests
     [Tags]    patch
     Create Session    httpbin    http://httpbin.org
@@ -263,6 +272,15 @@ Patch Requests
     ${resp}=    Patch Request    httpbin    /patch    data=${data}    headers=${headers}
     Dictionary Should Contain Value    ${resp.json()['form']}    bulkan
     Dictionary Should Contain Value    ${resp.json()['form']}    evcimen
+
+Patch Requests with Json Data
+    [Tags]  patch
+    Create Session  httpbin     http://httpbin.org
+    &{data}=    Create Dictionary   latitude=30.496346  longitude=-87.640356
+    ${resp}=     Patch Request  httpbin  /patch    json=${data}
+    Should Be Equal As Strings  ${resp.status_code}  200
+    ${jsondata}=  To Json  ${resp.content}
+    Should Be Equal     ${jsondata['json']}     ${data}
 
 Get Request With Redirection
     [Tags]  get

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -32,7 +32,7 @@ Get Requests with Json Data
     ${resp}=     Get Request  httpbin  /get    json=${data}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
-    Should Be Equal As Strings  ${resp.status_code}  200
+    # httpbin does not support this... Should be Equal     ${jsondata['json]}     ${data}
 
 Get HTTPS & Verify Cert
     [Tags]  get
@@ -68,6 +68,24 @@ Post Request With URL Params
     &{params}=   Create Dictionary   key=value     key2=value2
     ${resp}=  Post Request  httpbin  /post		params=${params}
     Should Be Equal As Strings  ${resp.status_code}  200
+
+Post Requests with Json Data
+    [Tags]  post
+    Create Session  httpbin     http://httpbin.org
+    &{data}=    Create Dictionary   latitude=30.496346  longitude=-87.640356
+    ${resp}=     Post Request  httpbin  /post    json=${data}
+    Should Be Equal As Strings  ${resp.status_code}  200
+    ${jsondata}=  To Json  ${resp.content}
+    Should be Equal     ${jsondata['json']}     ${data}
+
+Put Requests with Json Data
+    [Tags]  put
+    Create Session  httpbin     http://httpbin.org
+    &{data}=    Create Dictionary   latitude=30.496346  longitude=-87.640356
+    ${resp}=     Put Request  httpbin  /put    json=${data}
+    Should Be Equal As Strings  ${resp.status_code}  200
+    ${jsondata}=  To Json  ${resp.content}
+    Should be Equal     ${jsondata['json']}     ${data}
 
 Post Request With No Data
     [Tags]  post

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -23,7 +23,7 @@ Get Requests with Url Parameters
     ${resp}=     Get Request  httpbin  /get    params=${params}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
-    Should be Equal     ${jsondata['args']}     ${params}
+    Should Be Equal     ${jsondata['args']}     ${params}
 
 Get Requests with Json Data
     [Tags]  get
@@ -32,7 +32,7 @@ Get Requests with Json Data
     ${resp}=     Get Request  httpbin  /get    json=${data}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
-    # httpbin does not support this... Should be Equal     ${jsondata['json]}     ${data}
+    # httpbin does not support this... Should Be Equal     ${jsondata['json]}     ${data}
 
 Get HTTPS & Verify Cert
     [Tags]  get
@@ -76,7 +76,7 @@ Post Requests with Json Data
     ${resp}=     Post Request  httpbin  /post    json=${data}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
-    Should be Equal     ${jsondata['json']}     ${data}
+    Should Be Equal     ${jsondata['json']}     ${data}
 
 Put Requests with Json Data
     [Tags]  put
@@ -85,7 +85,7 @@ Put Requests with Json Data
     ${resp}=     Put Request  httpbin  /put    json=${data}
     Should Be Equal As Strings  ${resp.status_code}  200
     ${jsondata}=  To Json  ${resp.content}
-    Should be Equal     ${jsondata['json']}     ${data}
+    Should Be Equal     ${jsondata['json']}     ${data}
 
 Post Request With No Data
     [Tags]  post


### PR DESCRIPTION
Put Request and Post Request allow optional json parameter which will be json encoded data similar to files. This just wraps functionality of requests library, and works similar to recently added json parameter of Get Request