### PR TITLE
Fix project info classifiers to MIT license #177

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ Robot Framework keyword library wrapper around the HTTP client library requests.
 
 CLASSIFIERS = """
 Development Status :: 5 - Production/Stable
-License :: Public Domain
+License :: OSI Approved :: MIT License
 Operating System :: OS Independent
 Programming Language :: Python
 Topic :: Software Development :: Testing


### PR DESCRIPTION
Use tag MIT Licenses instead of Public Domain to match contents of LICENSE.md. Fixes issue #177 