### PR TITLE
Disables urllib warings

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -124,6 +124,8 @@ class RequestsKeywords(object):
         # verify can be a Boolean or a String
         if isinstance(verify, bool):
             s.verify = verify
+            if not verify:
+                requests.packages.urllib3.disable_warnings()
         elif isinstance(verify, str) or isinstance(verify, unicode):
             if verify.lower() == 'true' or verify.lower() == 'false':
                 s.verify = self.builtin.convert_to_boolean(verify)


### PR DESCRIPTION
with this, the parameter verify=${False} (default) will supress self
signed cert errors like below, which works for me :D
But this maybe not the idea behind it in first place.

I still think the logger set up  in "if disable_warnings" is wrong it
kills the robot logger settings so you do not see any warnings or debug
messages from my custom libraries any more.

unexpected error:
C:\Python27\lib\site-packages\urllib3\connectionpool.py:852:
InsecureRequestWarning: Unverified HTTPS request is being made. Adding
certificate verification is strongly advised. See:
https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:852:
InsecureRequestWarning: Unverified HTTPS request is being made. Adding
certificate verification is strongly advised. See:
https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)