### PR TITLE
disable cert warnings

### DIFF
--- a/src/RequestsLibrary/RequestsKeywords.py
+++ b/src/RequestsLibrary/RequestsKeywords.py
@@ -89,6 +89,7 @@ class RequestsKeywords(object):
         ``proxies`` Dictionary that contains proxy urls for HTTP and HTTPS communication
 
         ``verify`` Whether the SSL cert will be verified. A CA_BUNDLE path can also be provided.
+                   It will disable warnings about self signed certs too.
 
         ``debug`` Enable http verbosity option more information
                 https://docs.python.org/2/library/httplib.html#httplib.HTTPConnection.set_debuglevel
@@ -129,6 +130,8 @@ class RequestsKeywords(object):
         # verify can be a Boolean or a String
         if isinstance(verify, bool):
             s.verify = verify
+            if not verify:
+                requests.packages.urllib3.disable_warnings()
         elif isinstance(verify, str) or isinstance(verify, unicode):
             if verify.lower() == 'true' or verify.lower() == 'false':
                 s.verify = self.builtin.convert_to_boolean(verify)


### PR DESCRIPTION
Hi, I'm still confused with all this git stuff.
I hope this time I pulled the correct bulkan:master and applied the patch again, now with a little update help.

Here the old commit text:

with this, the parameter verify=${False} (default) will supress self
signed cert errors like below, which works for me :D
But this maybe not the idea behind it in first place.

I still think the logger set up  in "if disable_warnings" is wrong it
kills the robot logger settings so you do not see any warnings or debug
messages from my custom libraries any more.

unexpected error:
C:\Python27\lib\site-packages\urllib3\connectionpool.py:852:
InsecureRequestWarning: Unverified HTTPS request is being made. Adding
certificate verification is strongly advised. See:
https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)
C:\Python27\lib\site-packages\urllib3\connectionpool.py:852:
InsecureRequestWarning: Unverified HTTPS request is being made. Adding
certificate verification is strongly advised. See:
https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
InsecureRequestWarning)