### PR TITLE
Updates to work with Robot Framework 3.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ install:
   - "pip install -r requirements.txt"
 
 script:
-  - pybot --exclude skip -P src tests
+  - robot --exclude skip -P src tests

--- a/tests/testcase.txt
+++ b/tests/testcase.txt
@@ -181,7 +181,7 @@ Post Request With Binary Data
     &{headers}=  Create Dictionary  Content-Type=application/x-www-form-urlencoded
     ${resp}=  Post Request  httpbin  /post  data=${data}  headers=${headers}
     Log  ${resp.json()['form']}
-    ${value}=  evaluate  list(${resp.json()}['form'].keys())[0]
+    ${value}=  evaluate  list(${resp.json()['form']}.keys())[0]
     Should Contain  ${value}  度假村
 
 Post Request With Arbitrary Binary Data


### PR DESCRIPTION
These changes are included:

- Use `robot` instead of `pybot` in the CI job for running tests, as `pybot` has been removed
- Fix array access syntax for a test case