### PR TITLE
Failing test to show #259 issue and increased version to 0.6.4

### DIFF
--- a/src/RequestsLibrary/version.py
+++ b/src/RequestsLibrary/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.3'
+VERSION = '0.6.4'

--- a/tests/issues/259.robot
+++ b/tests/issues/259.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Library  ../../src/RequestsLibrary/RequestsKeywords.py
+Resource  ../res_setup.robot
+
+Suite Setup     Setup Flask Http Server
+Suite Teardown  Teardown Flask Http Server And Sessions
+
+
+*** Test Cases ***
+Post Content application/json With Empty Data Should Have No Body
+    ${content-type}=  Create Dictionary  content-type  application/json
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /anything  data=${EMPTY}  headers=${content-type}
+    Should Be Empty  ${resp.json()['data']}
+
+Post Content With Empty Data Should Have No Body
+    ${resp}=  Post Request  ${GLOBAL_LOCAL_SESSION}  /anything  data=${EMPTY}
+    Should Be Empty  ${resp.json()['data']}


### PR DESCRIPTION
An empty data is converted to "" string that is empty for json but not
for data and the raw body.
This happens only in case of application/json header for content-type